### PR TITLE
Update to include instructions for jupyter-notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,18 @@ If everything went well, this should open your browser (best with Google Chrome 
 
 ### Linux (Ubuntu/Debian)
 
-Only take these steps if you know what you are doing. Otherwise, simply download and install the Anaconda Python Distribution
+Only take these steps if you know what you are doing. Otherwise, simply download and install the Anaconda Python Distribution.
 
 First, open a terminal, then type
-
-    sudo apt-get install python3 ipython3 ipython3-notebook numpy scipy matplotlib 
+```bash
+# Debian 8 / Ubuntu 16.04
+$ sudo apt-get install python3 ipython3 ipython3-notebook numpy scipy matplotlib 
+```
+or
+```bash
+# Debian 9 / Ubuntu 17.04
+$ sudo apt-get install python3 jupyter-notebook numpy scipy matplotlib 
+```
 
 If you run another Linux distribution, similar packages should be available. Finally execute the file start-unix.sh.
 

--- a/start-unix.sh
+++ b/start-unix.sh
@@ -4,12 +4,12 @@ cd "$(dirname "$0")"
 
 source activate py34
 if [[ $? == 0 ]]; then
-	ipython notebook --matplotlib=inline
+	jupyter-notebook
 else
 	which ipython3
 	if [[ $? == 0 ]]; then
-		ipython3 notebook --matplotlib=inline
+		jupyter-notebook
 	else
-		ipython notebook --matplotlib=inline
+		jupyter-notebook
 	fi
 fi

--- a/start-unix.sh
+++ b/start-unix.sh
@@ -4,12 +4,12 @@ cd "$(dirname "$0")"
 
 source activate py34
 if [[ $? == 0 ]]; then
-	jupyter-notebook
+	jupyter-notebook || ipython-notebook --matplotlib=inline
 else
 	which ipython3
 	if [[ $? == 0 ]]; then
-		jupyter-notebook
+		 jupyter-notebook || ipython-notebook --matplotlib=inline
 	else
-		jupyter-notebook
+		jupyter-notebook || ipython-notebook --matplotlib=inline
 	fi
 fi


### PR DESCRIPTION
Since the time this course was written, development of the notebook functionality of ipython has split off into the separate jupyter project  and thus ipython-notebook is deprecated. I've just updated the Linux instructions and the start-unix.sh script to reflect this.

FYI, there is no --matplotlib flag in jupyter-notebook. Instead, it can be enable within the notebook by entering %matplotlib (sort of like an import statement).